### PR TITLE
Adding support for multistage-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 # Build the Go app
 RUN go build -o builder .
 
-# Start again with minimal envoirnment.
+# Start again with minimal environment.
 FROM spack/ubuntu-bionic:latest
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # builder
-The Autamus Builder GitHub Action
+
+The Autamus Builder GitHub Action. For an example of the builder in action,
+see the [autamus/registry](https://github.com/autamus/registry/blob/e9894541cb25e62f64555eb2a239612cee219aa3/.github/workflows/build-container.yml#L50)
+workflow.

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,27 @@ inputs:
     description: 'URL of the public key used to sign packages in the build cache, if applicable.'
     default: ''
     required: false
+  multistage_frompath:
+    description: Copy from this path.
+    default: ""
+    required: false
+  multistage_topath:
+    description: To this path. If not defined, the same fromPath is used.
+    default: ""
+    required: false
+  multistage_base:
+    description: The base of the multistage build
+    default: scratch
+    required: false
+  multistage_suffix:
+    description: The suffix to add to the container name for the multi-stage build container. 
+    default: "-layers"
+    required: false
+
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/autamus/builder:latest'
+  image: Dockerfile
+#  image: 'docker://ghcr.io/autamus/builder:latest'
 branding:
   icon: 'activity'
   color: 'white'

--- a/builder.go
+++ b/builder.go
@@ -10,6 +10,7 @@ import (
 
 	parser "github.com/autamus/binoc/repo"
 	"github.com/autamus/builder/config"
+	"github.com/autamus/builder/container"
 	"github.com/autamus/builder/repo"
 	"github.com/autamus/builder/spack"
 )
@@ -33,10 +34,17 @@ func main() {
 	packagesPath := filepath.Join(path, config.Global.Packages.Path)
 	containersPath := filepath.Join(path, config.Global.Containers.Path)
 	defaultEnvPath := filepath.Join(path, config.Global.Containers.DefaultEnVPath)
+
 	// Declare container values
 	currentContainer := config.Global.Containers.Current
 	currentVersion := ""
 	currentDockerfile := ""
+
+	// Variables for multi-stage build container
+	multistageToPath := config.Global.Multistage.Topath
+	multistageFromPath := config.Global.Multistage.Frompath
+	multistageBase := config.Global.Multistage.Base
+	multistageSuffix := config.Global.Multistage.Suffix
 
 	// Check if the current run is a PR
 	prVal, prExists := os.LookupEnv("GITHUB_EVENT_NAME")
@@ -72,6 +80,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+
 	} else {
 		output, err := ioutil.ReadFile(cPath)
 		if err != nil {
@@ -94,6 +103,31 @@ func main() {
 		log.Fatal(err)
 	}
 	f.Close()
+
+	// Generate a multistage build with the container
+	if multistageFromPath != "" {
+		fmt.Printf("Generating multistage build container.\n")
+		fmt.Println()
+		multistageDockerfile := container.MultiStageBuild(currentContainer,
+			currentVersion,
+			multistageToPath,
+			multistageFromPath,
+			multistageBase)
+
+		// Write the layer Dockerfile out to Disk
+		f, err := os.Create(filepath.Join(path, "Dockerfile.multistage"))
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = f.WriteString(multistageDockerfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		f.Close()
+
+		// Set multistage build suffix as output
+		fmt.Printf("::set-output name=multistage_suffix::%s\n", multistageSuffix)
+	}
 
 	// Save Container Name and Version as Output
 	fmt.Printf("::set-output name=container::%s\n", currentContainer)

--- a/config/config.go
+++ b/config/config.go
@@ -8,11 +8,12 @@ import (
 
 // Config defines the configuration struct for importing settings from ENV Variables
 type Config struct {
-	General    general
-	Packages   packages
 	Containers containers
-	Repository repository
+	General    general
+	Multistage multistage
+	Packages   packages
 	Parsers    parsers
+	Repository repository
 }
 
 type general struct {
@@ -33,6 +34,13 @@ type containers struct {
 type repository struct {
 	Path          string
 	DefaultBranch string
+}
+
+type multistage struct {
+	Topath	string
+	Frompath	string
+	Base	string
+	Suffix	string
 }
 
 type parsers struct {
@@ -57,6 +65,10 @@ func defaultConfig() {
 	Global.Repository.Path = "."
 	Global.Repository.DefaultBranch = "main"
 	Global.Parsers.Loaded = "spack"
+	Global.Multistage.Topath = ""
+	Global.Multistage.Frompath = ""
+	Global.Multistage.Base = "spack/ubuntu-bionic"
+	Global.Multistage.Suffix = "-layers"
 }
 
 func parseConfigEnv() {

--- a/container/multistage.go
+++ b/container/multistage.go
@@ -1,0 +1,21 @@
+package container
+
+// Multistage generates a Dockerfile for a multistage build
+func MultiStageBuild(currentContainer string, currentVersion string, toPath string, fromPath string, base string) string {
+
+	// If toPath not defined, toPath is the same as fromPath
+	if toPath == "" {
+		toPath = fromPath
+	}
+
+	// Create Dockerfile base
+	dockerfile := "FROM ghcr.io/autamus/" + currentContainer + ":" + currentVersion + " as base\n" +
+		"FROM " + base + "\n" +
+		"COPY --from=base " + fromPath + " " + toPath + "\n" +
+		"ENV PATH=/opt/spack/bin:$PATH\n" +
+		"WORKDIR /opt/spack\n" +
+		"RUN rm -rf /opt/spack/.spack-db/\n" +
+		"ENTRYPOINT [\"/bin/bash\"]\n"
+
+	return dockerfile
+}

--- a/spack/containerize.go
+++ b/spack/containerize.go
@@ -58,7 +58,9 @@ func Containerize(sEnv repo.SpackEnv, isPR bool, PublicKeyURL string) (dockerfil
 	dockerfile = strings.Replace(dockerfile, addHook, addCommand, 1)
 
 	// Add support for build cache
+	// The lines replaced here are the same line, one with and one without monitor
 	buildOld := "RUN cd /opt/spack-environment && spack env activate . && spack install --fail-fast && spack gc -y"
+	buildOldMonitor := "RUN  cd /opt/spack-environment && spack env activate . && export SPACKMON_USER=$(cat /run/secrets/su) && export SPACKMON_TOKEN=$(cat /run/secrets/st) && spack install --fail-fast && spack gc -y"
 	buildPublish := "RUN --mount=type=secret,id=aws_id " +
 		"--mount=type=secret,id=aws_secret " +
 		"--mount=type=secret,id=sign_key " +
@@ -80,8 +82,10 @@ func Containerize(sEnv repo.SpackEnv, isPR bool, PublicKeyURL string) (dockerfil
 	if len(sEnv.Spack.Mirrors) > 0 {
 		if isPR {
 			dockerfile = strings.Replace(dockerfile, buildOld, buildPR, 1)
+			dockerfile = strings.Replace(dockerfile, buildOldMonitor, buildPR, 1)
 		} else {
 			dockerfile = strings.Replace(dockerfile, buildOld, buildPublish, 1)
+			dockerfile = strings.Replace(dockerfile, buildOldMonitor, buildPublish, 1)
 		}
 	}
 


### PR DESCRIPTION
This pull request will add support for doing a multistage build - meaning a second Dockerfile (Dockerfile.layer) that can use the original container, copy over some source and destination, use some base container, and then generate an output variable for the suffix. I'm not sure how to test this locally, but I was thinking I could PR to autamus registry to try testing it out. What do you think @alecbcs ?
 
Signed-off-by: vsoch <vsoch@users.noreply.github.com>